### PR TITLE
Fix local host backuping bug

### DIFF
--- a/rsbu
+++ b/rsbu
@@ -597,7 +597,7 @@ then
                   then
                      echo "Not test mode. We ARE performing the backup."
                   fi
-                  rsync -aH --delete --link-dest=$LastBackupPath $Excludes $HostName$BackupData $TodaysBackupPath
+                  rsync -aH --delete --link-dest=$LastBackupPath $Excludes $BackupData $TodaysBackupPath
                else
                   if [ $verbose = 1 ]
                   then
@@ -642,7 +642,7 @@ then
                   then
                      echo "Not test mode. We ARE performing the backup."
                   fi
-                  rsync -aH --delete $Excludes $HostName$BackupData $TodaysBackupPath
+                  rsync -aH --delete $Excludes $BackupData $TodaysBackupPath
                else
                   if [ $verbose = 1 ]
                   then

--- a/rsbu.conf
+++ b/rsbu.conf
@@ -37,6 +37,8 @@ DeviceName[2]="4TB Seagate external USB HDD"
 # The pattern of these lines is as follows:                                    #
 # hostname;excludes;list of directories to back up                             #
 # Numbering must be sequential as this creates an array used by rsbu.          #
+# Local host list of directories to back up must be without colons             #
+# The pattern for local host see below (Backup [9]))                           #
 ################################################################################
 
 Backup[1]="david;--exclude .gvfs --exclude Cache --exclude yumdb;:/root :/etc :/home :/usr/local :/var/spool/cron :/Virtual :/stuff"
@@ -46,5 +48,9 @@ Backup[4]="wally1;--exclude Cache --exclude yumdb --exclude /var/log --exclude .
 Backup[5]="wally2;--exclude Cache --exclude yumdb --exclude /var/log --exclude .gvfs;:/root :/etc :/home :/var :/usr/local"
 Backup[6]="voyager;--exclude Cache --exclude yumdb --exclude .gvfs;:/root :/etc :/home :/var :/usr/local"
 Backup[7]="hornet;--exclude Cache --exclude yumdb --exclude /var/log;:/root :/etc :/home :/var :/usr/local"
+
 # The following definition is for test purposes
 # Backup[8]="enterprise;--exclude .gvfs --exclude /var/log;:/root :/etc :/home :/usr/local :/var"
+
+# The following definition is for local host only
+# Backup[9]="LOCALHOST;--exclude .cache --exclude .gvfs;/home/username"


### PR DESCRIPTION
Delete host name from rsync command line.
Delete colons from directories list in rsbu.conf.
Host name and colons in rsync command line caused ssh:...Connection
refused error for local host backuping.